### PR TITLE
fix: overrideDarkMode don't override with false

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -45,7 +45,8 @@ export const Toast: FC<Props> = ({
   const insets = useSafeAreaInsets();
   const { width, height } = useWindowDimensions();
   const { keyboardShown: keyboardVisible, keyboardHeight } = useKeyboard();
-  const isDarkMode = useColorScheme() === 'dark' || overrideDarkMode;
+  let isDarkMode = useColorScheme() === 'dark';
+  isDarkMode = overrideDarkMode ?? isDarkMode;
 
   const [toastHeight, setToastHeight] = useState<number>(
     toast?.height ? toast.height : DEFAULT_TOAST_HEIGHT


### PR DESCRIPTION
If dark mode is activated on the device and we want to override it with false it's keeps the useColorScheme()=== 'dark' return value and doesn't use the override value. 
This fix should solve this problem