### PR TITLE
fix: fix bad function pass in reanimated

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -96,6 +96,12 @@ export const Toast: FC<Props> = ({
   const offsetY = useSharedValue(startingY);
 
   const onPress = () => onToastPress?.(toast);
+  const dismiss = useCallback(
+    (id: string) => {
+      toasting.dismiss(id);
+    },
+    [toasting.dismiss]
+  );
 
   const setPosition = useCallback(() => {
     //control the position of the toast when rendering
@@ -146,7 +152,7 @@ export const Toast: FC<Props> = ({
         offsetY.value = withTiming(startingY, {
           duration: 40,
         });
-        runOnJS(toasting.dismiss)(toast.id);
+        runOnJS(dismiss)(toast.id);
       });
 
     return Gesture.Simultaneous(flingGesture, panGesture);


### PR DESCRIPTION
reanimated expects some sort of function built in a react component when calling runOnJS for workout purposes. Easiest way was to rebuild the function in the Toast component instead of marking the toast.dismiss function as a worklet so it can remain headless.