### PR TITLE
Added <GestureHandlerRootView>

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ npx expo install react-native-reanimated react-native-safe-area-context react-na
 <br />
 
 ### Cool, now what?
-Wrap your App with ``<GestureHandlerRootView></GestureHandlerRootView>`` & add the ``<Toasts />`` component to the root of your app. Call `toast("My Toast Message") whenever you are ready from *anywhere* in your app.
+Wrap your App with ``<GestureHandlerRootView />`` and ``<SafeAreaProvider />`` & add the ``<Toasts />`` component to the root of your app.
+
+Call ``toast("My Toast Message")`` whenever you are ready from *anywhere* in your app.
 
 ```js
 import { View, StyleSheet, Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { toast, Toasts } from '@backpackapp-io/react-native-toast';
 import { useEffect } from 'react';
 
@@ -61,10 +64,12 @@ export default function App() {
   }, []);
 
   return (
-    <GestureHandlerRootView style={styles.container}>
-      <View>{/*The rest of your app*/}</View>
-      <Toasts /> {/* <---- Add Here */}
-    </GestureHandlerRootView>
+    <SafeAreaProvider>
+      <GestureHandlerRootView style={styles.container}>
+        <View>{/*The rest of your app*/}</View>
+        <Toasts /> {/* <---- Add Here */}
+      </GestureHandlerRootView>
+    </SafeAreaProvider>
   );
 }
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ npx expo install react-native-reanimated react-native-safe-area-context react-na
 <br />
 
 ### Cool, now what?
-Add the ``<Toasts />`` component into the root of your app. Whenever you are ready, call `toast("My Toast Message")` from *anywhere* in your app.
+Wrap your App with ``<GestureHandlerRootView></GestureHandlerRootView>`` & add the ``<Toasts />`` component to the root of your app. Call `toast("My Toast Message") whenever you are ready from *anywhere* in your app.
 
 ```js
-import { StyleSheet, Text } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { toast, Toasts } from '@backpackapp-io/react-native-toast';
 import { useEffect } from 'react';
 
@@ -60,10 +61,10 @@ export default function App() {
   }, []);
 
   return (
-    <View style={styles.container}>
+    <GestureHandlerRootView style={styles.container}>
       <View>{/*The rest of your app*/}</View>
       <Toasts /> {/* <---- Add Here */}
-    </View>
+    </GestureHandlerRootView>
   );
 }
 


### PR DESCRIPTION
The developers behind react-native-gesture-handler made some breaking changes to their code, which made the react-native-toast component not spawn & only throw an error. I added the required wrapper to the readme.

https://stackoverflow.com/a/77309157
https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/#js