### PR TITLE
fix: toast keyboard offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,5 @@
       ]
     ]
   },
-  "dependencies": {},
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -158,5 +158,6 @@
       ]
     ]
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -25,12 +25,7 @@ import {
 
 import type { ExtraInsets, Toast as ToastType } from '../core/types';
 import { resolveValue, Toast as T, ToastPosition } from '../core/types';
-import {
-  colors,
-  ConstructShadow,
-  useKeyboard,
-  useVisibilityChange,
-} from '../utils';
+import { colors, ConstructShadow, useVisibilityChange } from '../utils';
 import { toast as toasting } from '../headless';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -48,6 +43,8 @@ type Props = {
   onToastHide?: (toast: T) => void;
   onToastPress?: (toast: T) => void;
   extraInsets?: ExtraInsets;
+  keyboardVisible?: boolean;
+  keyboardHeight: number;
   defaultStyle?: {
     pressable?: ViewStyle;
     view?: ViewStyle;
@@ -68,10 +65,11 @@ export const Toast: FC<Props> = ({
   onToastShow,
   extraInsets,
   defaultStyle,
+  keyboardVisible,
+  keyboardHeight,
 }) => {
   const insets = useSafeAreaInsets();
   const { width, height } = useWindowDimensions();
-  const { keyboardShown: keyboardVisible, keyboardHeight } = useKeyboard();
 
   useVisibilityChange(
     () => {

--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -6,6 +6,7 @@ import { Toast } from './Toast';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ExtraInsets } from '../core/types';
 import { useScreenReader } from 'src/core/utils';
+import { useKeyboard } from 'src/utils';
 
 type Props = {
   overrideDarkMode?: boolean;
@@ -37,6 +38,7 @@ export const Toasts: FunctionComponent<Props> = ({
   const { startPause, endPause } = handlers;
   const insets = useSafeAreaInsets();
   const isScreenReaderEnabled = useScreenReader();
+  const { keyboardShown: keyboardVisible, keyboardHeight } = useKeyboard();
 
   if (isScreenReaderEnabled && !preventScreenReaderFromHiding) {
     return null;
@@ -69,6 +71,8 @@ export const Toasts: FunctionComponent<Props> = ({
           onToastShow={onToastShow}
           extraInsets={extraInsets}
           defaultStyle={defaultStyle}
+          keyboardVisible={keyboardVisible}
+          keyboardHeight={keyboardHeight}
         />
       ))}
     </View>


### PR DESCRIPTION
There is an issue with Toasts being rendered under the keyboard. This is caused with incorrect position of the useKeyboard hook call, it should be called higher and passed down. When the Toast is shown while the keyboard is already visible it would not trigger the setPosition function.