### PR TITLE
fix: convert absolute imports with 'src/*' to relative imports

### DIFF
--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -9,8 +9,8 @@ import {
   ToastAnimationConfig,
   ToastAnimationType,
 } from '../core/types';
-import { useScreenReader } from 'src/core/utils';
-import { useKeyboard } from 'src/utils';
+import { useScreenReader } from '../core/utils';
+import { useKeyboard } from '../utils';
 
 type Props = {
   overrideDarkMode?: boolean;


### PR DESCRIPTION
Closes #43 

### Summary
In the latest version v0.12.0 the following error pops up right when initiating the app after the lib installation:
`Unable to resolve "src/core/utils" from "node_modules/@backpackapp-io/react-native-toast/src/components/Toasts.tsx"`

![Cursor 2024-11-12 22 23 26](https://github.com/user-attachments/assets/6bab08f7-bd77-45ae-8865-d942996fc715)

### Diagnostics

Upon evaluation, the error occurs due to an import located in the `components/Toasts.tsx` file, where it's done absolutely using the `src/` root. This causes the imported error detailed above, which the IDE also noticed when inspecting the file.

![Simulator 2024-11-12 22 23 45](https://github.com/user-attachments/assets/81da4728-ea30-4954-83e2-c2a7d5493c0f)

### Fix

Adjusting the absolute imports (there was already another one, just below the original one that caused the issue, when looking at the `master` branch) fixes the running issue, and the lib works just as expected.

Additionally, the change has no impact on this repository's `example` project. Which correctly compiles after the changes, as seen below:

![CleanShot 2024-11-12 at 22 37 05](https://github.com/user-attachments/assets/c9e56527-13e5-401c-9a58-004b31daefc8)
 
### Result

After the adjustment, the consumption in the final application works just as expected.

![CleanShot 2024-11-12 at 22 40 28](https://github.com/user-attachments/assets/929d0109-b735-412c-be20-a73da559947b)
