### PR TITLE
feat: don't wrap custom message components in `<Text>`

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -252,6 +252,8 @@ export const Toast: FC<Props> = ({
     };
   });
 
+  const resolvedValue = resolveValue(toast.message, toast);
+
   return (
     <GestureDetector key={toast.id} gesture={composedGesture}>
       <AnimatedPressable
@@ -342,19 +344,23 @@ export const Toast: FC<Props> = ({
             ) : (
               toast.icon
             )}
-            <Text
-              style={[
-                {
-                  color: isDarkMode ? colors.textLight : colors.textDark,
-                  padding: 4,
-                  flex: 1,
-                },
-                defaultStyle?.text,
-                toast?.styles?.text,
-              ]}
-            >
-              {resolveValue(toast.message, toast)}
-            </Text>
+            {typeof resolvedValue === 'string' ? (
+              <Text
+                style={[
+                  {
+                    color: isDarkMode ? colors.textLight : colors.textDark,
+                    padding: 4,
+                    flex: 1,
+                  },
+                  defaultStyle?.text,
+                  toast?.styles?.text,
+                ]}
+              >
+                {resolvedValue}
+              </Text>
+            ) : (
+              resolvedValue
+            )}
           </View>
         )}
       </AnimatedPressable>

--- a/website/docs/features/customization.md
+++ b/website/docs/features/customization.md
@@ -39,7 +39,7 @@ toast('Top Position with Extra Insets', {
 
 ## Styling Customization
 
-You can customize the toast style by passing the `styles` option to the `toast` function or by supplying a defaultStyle to the `<Toasts />` component.
+You can customize the toast style by passing the `styles` option to the `toast` function or by supplying a defaultStyle to the `<Toasts />` component. The `text` style is not applied if you pass a custom message component to the `toast` function.
 ```
 styles = {
   view?: ViewStyle;


### PR DESCRIPTION
All toast messages, both plain strings and custom components, were wrapped in `<Text>`. This prevented me from implementing the layout I wanted.

Take for example this example from the docs:
```tsx
const CustomMessage = (msg: string) => {
  return (
    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
      <Icon name="check" />
      <Text>{msg}</Text>
    </View>
  )
}

toast(<CustomMessage msg="Custom Message" />);
```
This would have been rendered like this:
```tsx
<Text style={[ /* ... */, toast?.styles?.text ]}>
  <View style={{ flexDirection: 'row', alignItems: 'center' }}>
    <Icon name="check" />
    <Text>{msg}</Text>
  </View>
</Text>
```
While having a `<View>` inside a `<Text>` is valid, it does limit what you can do as far as styling goes. You can't for example make your custom message component stretch to be the full width of the toast. I wanted to use `justifyContent: 'space-between'`, but because the View wasn't full width I couldn't get the appearance of my toast to be what I wanted.

Here's what I wanted to build
<img width="430" alt="image" src="https://github.com/user-attachments/assets/938ddd3b-bc48-4489-b1af-04a87d345e55" />
And with the `<Text>` element wrapping the custom message component it wasn't possible to use `justifyContent: 'space-between'` to get the down-chevron to go all the way over to the right side

So with this PR the outer `<Text>` is only used when the message is a plain string. If the message is a component the user is responsible for applying all the styles needed.