### PR TITLE
feat: allow config of max width

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -34,6 +34,7 @@ import { toast as toasting } from '../headless';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 const DEFAULT_TOAST_HEIGHT = 50;
+const MAX_WIDTH = 360;
 
 type Props = {
   toast: ToastType;
@@ -92,8 +93,9 @@ export const Toast: FC<Props> = ({
   const [toastHeight, setToastHeight] = useState<number>(
     toast?.height ? toast.height : DEFAULT_TOAST_HEIGHT
   );
+  const maxWidth = toast?.maxWidth ? toast.maxWidth : MAX_WIDTH;
   const [toastWidth, setToastWidth] = useState<number>(
-    toast?.width ? toast.width : width - 32 > 360 ? 360 : width - 32
+    toast?.width ? toast.width : width - 32 > maxWidth ? maxWidth : width - 32
   );
 
   const startingY = useMemo(
@@ -218,10 +220,11 @@ export const Toast: FC<Props> = ({
   }, [toast.height]);
 
   useEffect(() => {
+    const maxWidth = toast?.maxWidth ? toast.maxWidth : MAX_WIDTH;
     setToastWidth(
-      toast?.width ? toast.width : width - 32 > 360 ? 360 : width - 32
+      toast?.width ? toast.width : width - 32 > maxWidth ? maxWidth : width - 32
     );
-  }, [toast.width, width]);
+  }, [toast.width, toast.maxWidth, width]);
 
   useEffect(() => {
     opacity.value = withTiming(toast.visible ? 1 : 0, {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -220,11 +220,10 @@ export const Toast: FC<Props> = ({
   }, [toast.height]);
 
   useEffect(() => {
-    const maxWidth = toast?.maxWidth ? toast.maxWidth : MAX_WIDTH;
     setToastWidth(
       toast?.width ? toast.width : width - 32 > maxWidth ? maxWidth : width - 32
     );
-  }, [toast.width, toast.maxWidth, width]);
+  }, [toast.width, maxWidth, width]);
 
   useEffect(() => {
     opacity.value = withTiming(toast.visible ? 1 : 0, {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -81,6 +81,7 @@ export type ToastOptions = Partial<
     | 'isSwipeable'
     | 'animationConfig'
     | 'animationType'
+    | 'maxWidth'
   >
 >;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -50,6 +50,7 @@ export interface Toast {
   visible: boolean;
   height?: number;
   width?: number;
+  maxWidth?: number;
   styles?: {
     pressable?: ViewStyle;
     view?: ViewStyle;

--- a/website/docs/api/toast.md
+++ b/website/docs/api/toast.md
@@ -309,6 +309,17 @@ toast('my toast', {
 where `AutoWidthStyles` holds the actual styles for auto width.
 
 
+## Maximum Width
+You can set a maximum width for the toast by using the `maxWidth` option. This is useful when you want to limit the width of the toast to a certain value, regardless of the content size.
+*Note* If you provide a width to the toast, it will override the `maxWidth` option.
+```js
+toast('This toast has a maximum width', {
+  duration: 4000,
+  position: ToastPosition.TOP,
+  maxWidth: 100, // <-- Add here
+})
+```
+
 <br />
 
 ## All toast() Options
@@ -329,5 +340,5 @@ where `AutoWidthStyles` holds the actual styles for auto width.
 | `providerKey`   | string   | 'DEFAULT' | Provider key for the toast.                                                                  |
 | `accessibilityMessage`| string   |           | Accessibility message for screen readers.                                                    |
 | `styles`        | object   |           | Styles for the toast.                                                                        |
-
+| `maxWidth` | number |           | Maximum width of the toast.                                                                   |
 


### PR DESCRIPTION
I wanted the toasts to be full-width on my phone, but it's wider than 360. So I made the max width configurable.

Before:
![image](https://github.com/user-attachments/assets/4e362b23-aded-4581-8ef0-1a101a5c75f2)

After:
![image](https://github.com/user-attachments/assets/97372d59-3dd5-45dd-a2f4-240bba152e92)

If you want I can also make this configurable on a global level (on `<Toasts>`). And if you give me some pointers maybe I can add tests too. Just let me know what you want 🙂 